### PR TITLE
Ensure glossary styling is applied before initializers

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -63,6 +63,15 @@ const CHAPTER_GLOSSARY = {
 
 // INICIALIZACIÓN PRINCIPAL
 document.addEventListener('DOMContentLoaded', function() {
+    // Estilizar todas las glosas antes de inicializar otras funcionalidades
+    const rootStyles = getComputedStyle(document.documentElement);
+    const glosaColor = rootStyles.getPropertyValue('--glosa-color').trim();
+
+    document.querySelectorAll('.glosa').forEach(glosa => {
+        glosa.style.color = glosaColor;
+        glosa.style.borderBottom = `1px dotted ${glosaColor}`;
+    });
+
     initializeEmojiToggle();
     initializeGlossaryClick();
     initializeQuizzes();


### PR DESCRIPTION
## Summary
- Style all glossary (`.glosa`) elements inline on DOMContentLoaded using the configured `--glosa-color` before running other initializers.

## Testing
- ❌ `npm test` *(missing package.json)*
- ⚠️ `npm install jsdom` *(403 Forbidden while attempting to install jsdom for DOM emulation)*

------
https://chatgpt.com/codex/tasks/task_e_68a6bbcea2e88327996ec53e8b0d13f2